### PR TITLE
Tweaks

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -231,7 +231,15 @@ function ButtonsPanel(props: IButtonsPanelProps) {
   let { noMargin, children, center, left } = props;
   let align = "justify-between";
 
-  if (!Array.isArray(children) || children.length === 1) {
+  let nonEmptyChildren = [];
+
+  if (Array.isArray(children)) {
+    nonEmptyChildren = children.filter((child: any) => {
+      return child;
+    });
+  }
+
+  if (!Array.isArray(children) || nonEmptyChildren.length === 1) {
     align = "justify-end";
   }
 

--- a/src/Textarea.tsx
+++ b/src/Textarea.tsx
@@ -1,3 +1,4 @@
+import { Message } from "./Message";
 import { InfoButton } from "./InfoButton";
 import { Label } from "./Label";
 
@@ -81,9 +82,9 @@ function Textarea(props: ITextarea) {
       />
       {validationError &&
         (errorMessage && validationError.type === "required" ? (
-          <div className="error">{errorMessage}</div>
+          <Message.Error>{errorMessage}</Message.Error>
         ) : (
-          <div className="error p-0">{validationError.message}</div>
+          <Message.Error>{validationError.message}</Message.Error>
         ))}
       {infoButton && { infoButton }}
     </div>


### PR DESCRIPTION
- Check children for ButtonsPanel. When a condition validates to null or undefined it was still included in the list of children which caused alignment to be set incorrectly.
- Standardise validation error on Textarea to be the same as Input