### PR TITLE
Select input jumps page to top

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -400,7 +400,7 @@ function GroupedSelect(props: IGroupedSelect) {
                     >
                       {!noSearch && (
                         <Input
-                          autoFocus={true}
+                          autoFocus={false} // set too false to not make page jump on initial open
                           autoComplete="off"
                           inputId="ui-framework-search"
                           containerClassName="mt-4 w-full"


### PR DESCRIPTION
The page should not jump to the top when a select is opened for the first time