### PR TITLE
Add disablePressEscToClose property to useEffect dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uafrica-ui-framework",
-  "version": "1.2.125",
+  "version": "1.2.126",
   "description": "A ccd demustom set of UI components used by uAfrica.com, based on TailwindCSS and Headless UI",
   "license": "BSD-3-Clause",
   "repository": "uafrica/ui-framework",

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -50,7 +50,7 @@ const Base = ({
     } else {
       return;
     }
-  }, []);
+  }, [disablePressEscToClose]);
 
   function listenForEscape(e: any) {
     if (e.key === "Escape" && onHide !== undefined) {


### PR DESCRIPTION
Add disablePressEscToClose property to useEffect dependencies to allow for changing state of the disablePressEscToClose property, and not only setting the state on mount of the modal.