### PR TITLE
Fix possible typo?

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uafrica-ui-framework",
-  "version": "1.2.203",
+  "version": "1.2.204",
   "description": "A ccd demustom set of UI components used by uAfrica.com, based on TailwindCSS and Headless UI",
   "license": "BSD-3-Clause",
   "repository": "uafrica/ui-framework",

--- a/src/utils/dateUtils.tsx
+++ b/src/utils/dateUtils.tsx
@@ -22,7 +22,7 @@ function shortenFromNow(str: string): string {
 function pgFormatDate(date: string | Date | Moment | undefined): string {
   if (!date) return "";
   let momentDate: Moment = moment(date);
-  return momentDate.format("YYYY-MM-DD HH:mm:ssZ");
+  return momentDate.format("YYYY-MM-DD HH:mm:ss");
 }
 
 function humanFormatTime(date: string | Date | Moment | undefined, includeSeconds?: boolean): any {


### PR DESCRIPTION
Have a suspicion that this `momentDate.format("YYYY-MM-DD HH:mm:ssZ")` needs to be `momentDate.format("YYYY-MM-DD HH:mm:ss")`