### PR TITLE
Pagination to only fire when the page changes. Include event in orRowClicked function

### DIFF
--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -67,12 +67,18 @@ function Pagination({
                 onChange={(e: any) => {
                   setPageVal(e.target.value);
                 }}
-                onBlur={() => {
+                onBlur={(e: any) => {
+                  if (parseInt(e.target.value) === pageVal) {
+                    return;
+                  }
                   setActive(pageVal);
                   handler(pageVal);
                   scrollRef?.current?.scrollIntoView();
                 }}
                 onKeyDown={(e: any) => {
+                  if (parseInt(e.target.value) === pageVal) {
+                    return;
+                  }
                   if (e.key === "Enter" && active !== pageVal) {
                     setActive(pageVal);
                     handler(pageVal);

--- a/src/customTable/CustomTableRow.tsx
+++ b/src/customTable/CustomTableRow.tsx
@@ -57,7 +57,7 @@ function CustomTableRow(props: {
                 "custom-table-td pr-4 py-2 mx-1 " +
                 (onRowClicked && customTableUtils.isColumnClickable(column) ? "cursor-pointer" : "")
               }
-              onClick={() => {
+              onClick={(e: any) => {
                 onShowMenu(false);
 
                 if (onRowClicked && customTableUtils.isColumnClickable(column) && !isLoading) {
@@ -69,7 +69,8 @@ function CustomTableRow(props: {
                     },
                     removeRow: () => {
                       props.removeRow(dataIndex);
-                    }
+                    },
+                    e: e
                   });
                 }
               }}


### PR DESCRIPTION
Add event in the `onRowClicked` function for the custom table to allow the user:

```
openNewTap(row.e, `/whatever_url/${row.original.id}`);
```
Also, do not fire the handler for the pagination component if it should not be fired