### PR TITLE
Add popover height prop to select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-group-ui-framework",
-  "version": "1.2.229",
+  "version": "1.2.230",
   "description": "A ccd demustom set of UI components used by Bob Group, based on TailwindCSS and Headless UI",
   "license": "BSD-3-Clause",
   "repository": "uafrica/ui-framework",

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -46,9 +46,10 @@ interface IBase {
   allowDeselect?: boolean; // single select mode does not allow for the deselection of an option by default, only switching to another option. override by setting this to true
   showAsterisk?: boolean;
   dataTest?: string | undefined;
-  showAllButton?: boolean;// conditionally display a button to show all available options
-  showAllSelectedText?: boolean;// show "All selected" if the options selected is equal to the amount of options in the array
+  showAllButton?: boolean; // conditionally display a button to show all available options
+  showAllSelectedText?: boolean; // show "All selected" if the options selected is equal to the amount of options in the array
   allSelectedText?: string | undefined; // custom all selected text
+  popoverHeight?: string;
 }
 
 // Implementation
@@ -81,7 +82,8 @@ function GroupedSelect(props: IGroupedSelect) {
     dataTest,
     showAllButton,
     showAllSelectedText,
-    allSelectedText
+    allSelectedText,
+    popoverHeight
   } = props;
 
   const popupNode = useRef<HTMLElement>();
@@ -254,7 +256,7 @@ function GroupedSelect(props: IGroupedSelect) {
           labelWithValue = selectedItem.label;
         }
       } else if (value.length === flattenedOptions.length && showAllSelectedText) {
-        labelWithValue = allSelectedText ?? "All selected"
+        labelWithValue = allSelectedText ?? "All selected";
       } else if (value.length > 1) {
         labelWithValue = value.length + " selected";
       }
@@ -328,13 +330,13 @@ function GroupedSelect(props: IGroupedSelect) {
             } else {
               // select all, ignore disabled options
               onChange &&
-              onChange(
-                (flattenedOptions ? flattenedOptions : [])
-                  .filter((option: { value: string | number; disabled?: boolean }) => {
-                    return notSelectedDisabledOptions.indexOf(option.value) === -1;
-                  })
-                  .map(option => option.value)
-              );
+                onChange(
+                  (flattenedOptions ? flattenedOptions : [])
+                    .filter((option: { value: string | number; disabled?: boolean }) => {
+                      return notSelectedDisabledOptions.indexOf(option.value) === -1;
+                    })
+                    .map(option => option.value)
+                );
             }
           }}
         />
@@ -473,7 +475,11 @@ function GroupedSelect(props: IGroupedSelect) {
                           {selectAllButton}
                         </div>
                       )}
-                      <div className={"mt-2 mb-2 max-h-52 overflow-y-auto"}>
+                      <div
+                        className={`mt-2 mb-2 ${
+                          popoverHeight ? popoverHeight : "max-h-52 "
+                        } overflow-y-auto`}
+                      >
                         {allOptionsSearched.length === 0 && (
                           <div className="pl-2 mt-2">No options</div>
                         )}


### PR DESCRIPTION
Esteemed colleagues,

I present to you a proposal for the enrichment of our Select component. It has come to my attention that certain circumstances require a height adjustment to the popover that arises upon clicking the component. Thus, I have endeavoured to introduce a new property to the Select component, one that will grant the developer the ability to specify the height of said popover.

By default, the maximum height of the popover shall be set at `24rem` (max-h-52). Yet, with the inclusion of the new property, entitled "popoverHeight," the developer may pass in a string value (this will be added to the `className`) to adjust the height of the popover accordingly. In this manner, the new property serves as a valuable tool to ensure that all select options remain visible to the user without unnecessary scrolling or overflow.

To utilise the "popoverHeight" property, the developer must simply pass the integer value as follows:

```
<Select popoverHeight={"h-3000"} ...restProps />
```

The above code shall add `h-3000` to the className of the div that limits the maximum height of the popover.

I hope that this proposal meets with your approval and I eagerly anticipate your feedback on this matter.

Respectfully submitted,

Three Putt King