### PR TITLE
Force bold text for table counts

### DIFF
--- a/src/utils/tableUtils.tsx
+++ b/src/utils/tableUtils.tsx
@@ -62,12 +62,8 @@ function getTableCountDivWithDateRangeIndication(
   absolute_query?: string,
   startDate?: any,
   endDate?: any,
-  absoluteQueryOptions?: any,
-  isBold?: boolean
+  absoluteQueryOptions?: any
 ) {
-  if (isBold !== undefined) {
-    isBold = true;
-  }
   if (!absolute_query) {
     absolute_query = "date_range";
   }
@@ -132,7 +128,7 @@ function getTableCountDivWithDateRangeIndication(
         <Loader.Inline title="Loading" />
       ) : (
         <span className="no-print">
-          <div className={isBold ? "font-bold" : ""}>
+          <div className="font-bold">
             {displayString}
             {timeRangeString}
           </div>


### PR DESCRIPTION
The UX team has created tickets on all projects to make this text always be bold and asked that we remove the option of having it not be bold for consistency